### PR TITLE
Updated caniuse-lite and browser support library packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5778,11 +5778,6 @@
             "update-browserslist-db": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001359",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001359.tgz",
-          "integrity": "sha512-Xln/BAsPzEuiVLgJ2/45IaqD9jShtk3Y33anKb4+yLwQzws3+v6odKfpgES/cDEaZMLzSChpIGdbOYtH9MyuHw=="
-        },
         "electron-to-chromium": {
           "version": "1.4.169",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.169.tgz",
@@ -6751,9 +6746,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001279",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-      "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
+      "version": "1.0.30001359",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001359.tgz",
+      "integrity": "sha512-Xln/BAsPzEuiVLgJ2/45IaqD9jShtk3Y33anKb4+yLwQzws3+v6odKfpgES/cDEaZMLzSChpIGdbOYtH9MyuHw=="
     },
     "capital-case": {
       "version": "1.0.4",
@@ -7499,11 +7494,6 @@
             "node-releases": "^2.0.1",
             "picocolors": "^1.0.0"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001284",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001284.tgz",
-          "integrity": "sha512-t28SKa7g6kiIQi6NHeOcKrOrGMzCRrXvlasPwWC26TH2QNdglgzQIRUuJ0cR3NeQPH+5jpuveeeSFDLm2zbkEw=="
         },
         "electron-to-chromium": {
           "version": "1.4.11",
@@ -18135,11 +18125,6 @@
             "update-browserslist-db": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001359",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001359.tgz",
-          "integrity": "sha512-Xln/BAsPzEuiVLgJ2/45IaqD9jShtk3Y33anKb4+yLwQzws3+v6odKfpgES/cDEaZMLzSChpIGdbOYtH9MyuHw=="
-        },
         "electron-to-chromium": {
           "version": "1.4.169",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.169.tgz",
@@ -18811,11 +18796,6 @@
             "node-releases": "^2.0.5",
             "update-browserslist-db": "^1.0.0"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001359",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001359.tgz",
-          "integrity": "sha512-Xln/BAsPzEuiVLgJ2/45IaqD9jShtk3Y33anKb4+yLwQzws3+v6odKfpgES/cDEaZMLzSChpIGdbOYtH9MyuHw=="
         },
         "chalk": {
           "version": "4.1.2",


### PR DESCRIPTION
- ran npx browserslist@latest --update-db
- this updates package-lock file with latest browsers support list for caniuse-lite
<img width="466" alt="Screen Shot 2022-06-27 at 12 44 26" src="https://user-images.githubusercontent.com/4358288/176022979-abb7ae0a-4c0b-4def-80c6-712e7f78dd7a.png">

