### PR TITLE
Fix broken link re-direction on 'Labs docs' link in the header

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -534,7 +534,7 @@ class Header extends React.Component {
         <nav className="navbar-v6 navbar navbar-expand-lg navbar-light bg-light nav-secondary blurred-container">
           <Link
             className="navbar-brand"
-            href="/"
+            href="/labs"
           >
             <span id="learning-center-home-link" className="nav-link uber-nav">
               Postman Labs Docs

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -534,7 +534,7 @@ class Header extends React.Component {
         <nav className="navbar-v6 navbar navbar-expand-lg navbar-light bg-light nav-secondary blurred-container">
           <Link
             className="navbar-brand"
-            href="/labs"
+            href="/labs/"
           >
             <span id="learning-center-home-link" className="nav-link uber-nav">
               Postman Labs Docs


### PR DESCRIPTION
## Issue:
Clicking on the Labs docs link in the header takes me to `learning.postman.com` instead of `learning.postman.com/labs`