### PR TITLE
Add gRPC testing docs

### DIFF
--- a/src/components/LeftNav/LeftNavItems.jsx
+++ b/src/components/LeftNav/LeftNavItems.jsx
@@ -116,6 +116,29 @@ export const leftNavItems = [
         url: "/postman-api-client/grpc-client/using-service-definition/",
       },
       {
+        name: "Writing scripts",
+        subParentSlug: "writing-scripts",
+        slug: "/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/",
+        subMenuItems2: [
+          {
+            name: 'Scripting in gRPC request',
+            url: "/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/",
+          },
+          {
+            name: 'Writing tests',
+            url: "/postman-api-client/grpc-client/writing-scripts/writing-tests/",
+          },
+          {
+            name: 'Test examples',
+            url: "/postman-api-client/grpc-client/writing-scripts/test-examples/",
+          },
+          {
+            name: 'Postman Sandbox API',
+            url: "/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/",
+          }
+        ]
+      },
+      {
         name: "Understanding gRPC types",
         url: "/postman-api-client/grpc-client/understanding-grpc-types/",
       },

--- a/src/pages/postman-api-client/grpc-client/first-grpc-request.md
+++ b/src/pages/postman-api-client/grpc-client/first-grpc-request.md
@@ -24,7 +24,7 @@ gRPC supports 4 types of methods that allow the client and server to interact in
 
 - **Bidirectional streaming**: With bidirectional streaming, the client and server can communicate with each other asynchronously over a persistent session.
 
-In this example, we will be creating and executing a unary request which is more commonly used than the rest. To learn about invoking the other method types, head over to [working with requests](postman-api-client/grpc-client/using-grpc-request).
+In this example, we will be creating and executing a unary request which is more commonly used than the rest. To learn about invoking the other method types, head over to [working with requests](/postman-api-client/grpc-client/using-grpc-request/).
 
 Now that we have covered the basics, let’s invoke our first gRPC request!
 
@@ -36,7 +36,7 @@ Open Postman and follow the steps:
 
 1. Enter the URL as: `grpc://grpcb.in:9000`. This is an echo endpoint that allows you to try out various types of services and methods.
 
-1. Click on the **Method selection dropdown** next and browse through all the supported services and methods. When you enter the URL, Postman automatically loads the service definition using server reflection (if supported by the server). If server reflection is disabled on the server, you will have to load the service definition manually. Learn more about [working with service definitions](postman-api-client/grpc-client/using-service-definition).
+1. Click on the **Method selection dropdown** next and browse through all the supported services and methods. When you enter the URL, Postman automatically loads the service definition using server reflection (if supported by the server). If server reflection is disabled on the server, you will have to load the service definition manually. Learn more about [working with service definitions](/postman-api-client/grpc-client/using-service-definition/).
 
 1. Now, from the list of methods, scroll down and select **SayHello**. This is a unary method.
 
@@ -68,4 +68,4 @@ In this example, Postman is acting as the client application and is communicatin
 
 Try invoking some other methods available on the gRPC bin server and see how things act differently.
 
-When you’re done, learn more about [working with requests](postman-api-client/grpc-client/using-grpc-request).
+When you’re done, learn more about [working with requests](/postman-api-client/grpc-client/using-grpc-request/).

--- a/src/pages/postman-api-client/grpc-client/grpc-request-interface.md
+++ b/src/pages/postman-api-client/grpc-client/grpc-request-interface.md
@@ -65,7 +65,7 @@ A gRPC payload can contain a few things to aid the server in executing the reque
 
 You can compose a message in JSON to send along with the request. As per the backend logic, the server uses this message to perform appropriate actions and gives you a response in return.
 
-<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/compose-message.jpeg" alt="Request pane">
+<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/compose-message.jpeg" alt="Message composition area">
 
 **Message actions:** Message actions can be used to shape and aid in message composition. The **Beautify** button makes the composed JSON message presentable and readable for external users using advanced formatting. And to make your job of composing a message easier, the **Generate example message** button creates a dummy message using the schema once you have selected the method to invoke.
 

--- a/src/pages/postman-api-client/grpc-client/grpc-request-interface.md
+++ b/src/pages/postman-api-client/grpc-client/grpc-request-interface.md
@@ -65,7 +65,9 @@ A gRPC payload can contain a few things to aid the server in executing the reque
 
 You can compose a message in JSON to send along with the request. As per the backend logic, the server uses this message to perform appropriate actions and gives you a response in return.
 
-**Message actions:** Message actions can be used to shape and aid in message composition.
+<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/compose-message.jpeg" alt="Request pane">
+
+**Message actions:** Message actions can be used to shape and aid in message composition. The **Beautify** button makes the composed JSON message presentable and readable for external users using advanced formatting. And to make your job of composing a message easier, the **Generate example message** button creates a dummy message using the schema once you have selected the method to invoke.
 
 <img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/message-actions.jpeg" alt="Message actions" width="300px">
 
@@ -88,14 +90,6 @@ Postman contains a powerful scripting environment that allows you to add Javascr
 Learn more about [scripting in gRPC request](/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/).
 
 <img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/scripts.jpeg" alt="Scripts in gRPC request">
-
-#### Beautify
-
-The 'Beautify' button makes the composed JSON message presentable and readable for external users using advanced formatting.
-
-#### Generate example message
-
-gRPC being a schema-driven framework requires the client to only use the fields and associated datatypes defined in the service definition. So, to make your job of composing a message easier, the 'Generate example message' button creates a dummy message using the schema once you have selected the method to invoke.
 
 ### TLS Toggle
 

--- a/src/pages/postman-api-client/grpc-client/grpc-request-interface.md
+++ b/src/pages/postman-api-client/grpc-client/grpc-request-interface.md
@@ -23,7 +23,6 @@ gRPC request in Postman packs a variety of tools, views and controls to help you
     * [Method](#method)
     * [Payload](#payload)
     * [Scripts](#scripts)
-    * [Message actions](#message-actions)
     * [TLS Toggle](#tls-toggle)
     * [Invoke button](#invoke-button)
     * [Request name](#request-name)
@@ -66,6 +65,12 @@ A gRPC payload can contain a few things to aid the server in executing the reque
 
 You can compose a message in JSON to send along with the request. As per the backend logic, the server uses this message to perform appropriate actions and gives you a response in return.
 
+**Message actions**
+
+Message actions can be used to shape and aid in message composition.
+
+<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/message-actions.jpeg" alt="Message actions" width="300px">
+
 #### Authorization
 
 Using the Authorization section, you can pass the credentials that the server would use to authorize the connection. Depending on the server requirement you can choose from a list of Auth types that include: API Key, Basic auth and Bearer token.
@@ -85,12 +90,6 @@ Postman contains a powerful scripting environment that allows you to add Javascr
 Learn more about [scripting in gRPC request](/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/).
 
 <img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/scripts.jpeg" alt="Scripts in gRPC request">
-
-### Message actions
-
-Message actions can be used to shape and aid in message composition.
-
-<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/message-actions.jpeg" alt="Message actions" width="300px">
 
 #### Beautify
 

--- a/src/pages/postman-api-client/grpc-client/grpc-request-interface.md
+++ b/src/pages/postman-api-client/grpc-client/grpc-request-interface.md
@@ -160,7 +160,7 @@ Look for specific things within the response using the 'Search' button.
 
 While invoking a streaming method type (client streaming, server streaming or bidirectional streaming), the client-server communication within a single session is recorded in the response area as a series of sent and received messages in a timeline instead of a single response. Learn more about [different method types](postman-api-client/grpc-client/using-grpc-request).
 
-<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/response-stream.jpeg" alt="Response stream" width="400px">
+<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/response-stream-sections.jpeg" alt="Response stream">
 
 #### Connection status
 

--- a/src/pages/postman-api-client/grpc-client/grpc-request-interface.md
+++ b/src/pages/postman-api-client/grpc-client/grpc-request-interface.md
@@ -65,9 +65,7 @@ A gRPC payload can contain a few things to aid the server in executing the reque
 
 You can compose a message in JSON to send along with the request. As per the backend logic, the server uses this message to perform appropriate actions and gives you a response in return.
 
-**Message actions**
-
-Message actions can be used to shape and aid in message composition.
+**Message actions:** Message actions can be used to shape and aid in message composition.
 
 <img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/message-actions.jpeg" alt="Message actions" width="300px">
 

--- a/src/pages/postman-api-client/grpc-client/grpc-request-interface.md
+++ b/src/pages/postman-api-client/grpc-client/grpc-request-interface.md
@@ -22,6 +22,7 @@ gRPC request in Postman packs a variety of tools, views and controls to help you
     * [Server URL](#server-url)
     * [Method](#method)
     * [Payload](#payload)
+    * [Scripts](#scripts)
     * [Message actions](#message-actions)
     * [TLS Toggle](#tls-toggle)
     * [Invoke button](#invoke-button)
@@ -33,6 +34,7 @@ gRPC request in Postman packs a variety of tools, views and controls to help you
     * [Wrap text button](#wrap-text-button)
     * [Search through response](#search-through-response)
     * [Multiple responses](#multiple-responses)
+    * [Test results](#test-results)
 * [Right sidebar](#right-sidebar)
     * [Request documentation](#request-documentation)
     * [Comments](#comments)
@@ -52,7 +54,7 @@ The server URL is used to define the endpoint where the service is hosted. Being
 
 ### Method
 
-You can select the method you wish to invoke using the method selector dropdown. The list of methods is populated by the service definition which is loaded automatically soon after you enter the URL if the server supports server reflection. Else you will be required to load a service definition manually either by uploading a .proto file or creating a Protobuf API in Postman. Learn more about [working with service definition](postman-api-client/grpc-client/using-service-definition).
+You can select the method you wish to invoke using the method selector dropdown. The list of methods is populated by the service definition which is loaded automatically soon after you enter the URL if the server supports server reflection. Else you will be required to load a service definition manually either by uploading a .proto file or creating a Protobuf API in Postman. Learn more about [working with service definition](/postman-api-client/grpc-client/using-service-definition/).
 
 <img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/methods-list.jpeg" alt="Method selection dropdown" width="500px">
 
@@ -75,6 +77,14 @@ Using the Authorization section, you can pass the credentials that the server wo
 You can pass additional metadata along with the request in the form of key-value pairs. Metadata is used by the client to provide “more information“ about the call to the server and vice versa.
 
 <img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/metadata-tab.jpeg" alt="Metadata configuration">
+
+### Scripts
+
+Postman contains a powerful scripting environment that allows you to add Javascript code (a.k.a scripts) in your gRPC requests. You can use scripts to write API tests, debug your requests (by logging to [Postman Console](https://learning.postman.com/docs/sending-requests/troubleshooting-api-requests/)), or even dynamically read/update the values of [variables](http://localhost:8000/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/(https://learning.postman.com/docs/sending-requests/variables/)).
+
+Learn more about [scripting in gRPC request](/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/).
+
+<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/scripts.jpeg" alt="Scripts in gRPC request">
 
 ### Message actions
 
@@ -158,7 +168,7 @@ Look for specific things within the response using the 'Search' button.
 
 ### Multiple responses
 
-While invoking a streaming method type (client streaming, server streaming or bidirectional streaming), the client-server communication within a single session is recorded in the response area as a series of sent and received messages in a timeline instead of a single response. Learn more about [different method types](postman-api-client/grpc-client/using-grpc-request).
+While invoking a streaming method type (client streaming, server streaming or bidirectional streaming), the client-server communication within a single session is recorded in the response area as a series of sent and received messages in a timeline instead of a single response. Learn more about [different method types](/postman-api-client/grpc-client/using-grpc-request/).
 
 <img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/response-stream-sections.jpeg" alt="Response stream">
 
@@ -194,6 +204,14 @@ Using the ‘Clear messages' button hides all the messages exchanged from the vi
 
 <img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/hide-messages.jpeg" alt="Clear messages">
 
+### Test results
+
+The results for assertions you write in the Scripts section appear here. Based on the test script, the results can be of 3 types: Passed, Failed, and Skipped.
+
+Learn more about [scripting in gRPC request](/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/).
+
+<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/request-interface/test-results.jpeg" alt="gRPC test results">
+
 ## Right sidebar
 
 The right sidebar gives you access to additional tools and information like documentation, commenting and meta information on the request.
@@ -214,4 +232,4 @@ The request information pane shows additional details about the request like req
 
 ## Next step
 
-Now that you understand all the basic interface elements, go ahead and [create a grpc request on Postman](postman-api-client/grpc-client/first-grpc-request).
+Now that you understand all the basic interface elements, go ahead and [create a grpc request on Postman](/postman-api-client/grpc-client/first-grpc-request/).

--- a/src/pages/postman-api-client/grpc-client/using-grpc-request.md
+++ b/src/pages/postman-api-client/grpc-client/using-grpc-request.md
@@ -22,6 +22,9 @@ A gRPC request in Postman let you work with gRPC APIs. It can be used to invoke 
     * [Adding service definition](#adding-service-definition)
     * [Selecting a method to invoke](#selecting-a-method-to-invoke)
     * [Adding a message](#adding-a-message)
+    * [Adding auth details](#adding-auth-details)
+    * [Adding metadata](#adding-metadata)
+    * [Writing scripts](#writing-scripts)
     * [Using TLS and certificates](#using-tls-and-certificates)
 * [Invoking different types of methods](#invoking-different-types-of-methods)
     * [Invoking a unary method](#invoking-a-unary-method)
@@ -88,6 +91,14 @@ Learn more about [authorizing your requests](https://learning.postman.com/docs/s
 You can add metadata to provide additional information about the execution to the server. Metadata is defined using a bunch of key-value pairs that you can add directly to the **Metadata tab**.
 
 <img src="https://assets.postman.com/postman-labs-docs/grpc-docs/using-grpc-request/metadata-tab.jpeg" alt="Adding metadata">
+
+### Writing scripts
+
+Postman contains a powerful scripting environment that allows you to add Javascript code (a.k.a scripts) in your gRPC requests. You can use scripts to write API tests, debug your requests (by logging to [Postman Console](https://learning.postman.com/docs/sending-requests/troubleshooting-api-requests/)), or even dynamically read/update the values of [variables](http://localhost:8000/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/(https://learning.postman.com/docs/sending-requests/variables/)).
+
+Learn more about [scripting in gRPC request](/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/).
+
+<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/using-grpc-request/scripts.jpeg" alt="Writing scripts">
 
 ### Using TLS and certificates
 

--- a/src/pages/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api.md
+++ b/src/pages/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api.md
@@ -1,0 +1,234 @@
+---
+title: "Postman Sandbox API"
+page_id: "postman-sandbox-api"
+warning: false
+updated: 2022-07-22
+contextual_links:
+  - type: section
+    name: "Prerequisites"
+  - type: link
+    name: "Scripting in gRPC request"
+    url: "/postman-api-client/grpc-client/writing-scripts/writing-tests/#scripting-in-grpc-request"
+  - type: link
+    name: "Using variables"
+    url: "https://learning.postman.com/docs/sending-requests/variables/"
+---
+
+Postman provides JavaScript APIs via the `pm` object that you can use in your gRPC request scripts, executed in [Postman Sandbox](https://github.com/postmanlabs/postman-sandbox).
+
+## Contents
+
+* [The pm object](#the-pm-object)
+    * [Accessing contextual information in scripts](#accessing-contextual-information-in-scripts)
+        * [pm.request](#pmrequest)
+        * [pm.response](#pmresponse)
+        * [pm.info](#pminfo)
+    * [Writing assertions](#writing-assertions)
+        * [pm.test](#pmtest)
+        * [pm.expect](#pmexpect)
+    * [Using variables in scripts](#using-variables-in-scripts)
+* [Using external libraries](#using-external-libraries)
+
+## The pm object
+
+The `pm` object provides functionality for testing your request and response data, access to variables, and some meta information.
+
+### Accessing contextual information in scripts
+
+#### pm.request
+
+The `pm.request` object provides access to the request data inside your scripts. `pm.request` is available in both **Pre-invoke** and **Response** scripts.
+
+Following are the properties of the `pm.request` object:
+
+* The request URL:
+  
+  ><code>pm.request.url: <a href='https://www.postmanlabs.com/postman-collection/Url.html' target='_blank'>Url</a></code>
+
+* The package, service and method name in the format `packageName.serviceName.methodName`:
+  
+  ><code>pm.request.methodPath: <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#string_type' target='_blank'>string</a></code>
+
+* Authentication details:
+  
+  ><code>pm.request.auth: <a href='https://www.postmanlabs.com/postman-collection/RequestAuth.html' target='_blank'>Auth</a></code>
+
+* The list of metadata sent with the request:
+  
+  ><code>pm.request.metadata: <a href='https://www.postmanlabs.com/postman-collection/PropertyList.html' target='_blank'>PropertyList&lt;{ key: string, value: string }&gt;</a></code>
+
+  An individual metadata item is an object with properties `key` and `value`.
+
+* The list of outgoing messages:
+
+  ><code>pm.request.messages: <a href='https://www.postmanlabs.com/postman-collection/PropertyList.html' target='_blank'>PropertyList&lt;{ data: any, timestamp: Date }&gt;</a></code>
+
+  An individual message is an object with properties:
+    * `data`: the sent message content, and
+    * `timestamp`: time at which the message was sent (<a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date' target='_blank'>Date</a>) object).
+  
+  For requests with unary and server streaming methods, `pm.request.messages` will contain only one message at index 0 which can be accessed as `pm.request.messages.idx(0)`.
+
+> Note: Request mutation is not supported yet via the `pm` object.
+
+#### pm.response
+
+The `pm.response` object provides access to the data returned in the response for the current request execution. `pm.response` is only available in the **Response** scripts.
+
+Following are the properties of the `pm.response` object:
+
+* The <a href='https://grpc.github.io/grpc/core/md_doc_statuscodes.html' target='_blank'>gRPC response status code</a>:
+
+  ><code>pm.response.statusCode: <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#number_type' target='_blank'>number</a></code>
+
+* Response time (in milliseconds):
+  
+  ><code>pm.response.responseTime: <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#number_type' target='_blank'>number</a></code>
+
+  For requests with streaming methods, `responseTime` denotes the total duration for that request execution.
+
+* The list of metadata received with the response:
+  
+  ><code>pm.response.metadata: <a href='https://www.postmanlabs.com/postman-collection/PropertyList.html' target='_blank'>PropertyList&lt;{ key: string, value: string }&gt;</a></code>
+
+  An individual metadata item is an object with properties `key` and `value`.
+
+* The list of trailers received with the response:
+  
+  ><code>pm.response.trailers: <a href='https://www.postmanlabs.com/postman-collection/PropertyList.html' target='_blank'>PropertyList&lt;{ key: string, value: string }&gt;</a></code>
+
+  An individual trailer item is an object with properties `key` and `value`.
+
+* The list of incoming messages:
+  ><code>pm.response.messages: <a href='https://www.postmanlabs.com/postman-collection/PropertyList.html' target='_blank'>PropertyList&lt;{ data: any, timestamp: Date }&gt;</a></code>
+
+  An individual message is an object with properties:
+    * `data`: the received message content, and
+    * `timestamp`: time at which the message was received (<a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date' target='_blank'>Date</a>).
+
+  For requests with unary and client streaming methods, `pm.response.messages` will contain only one message at index 0 which can be accessed as `pm.response.messages.idx(0)`.
+
+#### pm.info
+
+The `pm.info` object provides meta information related to the request and the script itself, including  the request name, request ID, and name of the execution hook.
+
+Following are the properties of the `pm.info` object:
+
+* The name of execution hook. It will be either `preinvoke` or `response` depending if the script is executing in **Pre-invoke** or **Response** hook respectively.
+  
+  ><code>pm.info.eventName: 'preinvoke' | 'response'</code>
+
+* A unique ID that identifies the current request inside which the script is running:
+  
+  ><code>pm.info.requestId: <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#string_type' target='_blank'>string</a></code>
+
+* The request name:
+  
+  ><code>pm.info.requestName: <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#string_type' target='_blank'>string</a></code>
+
+### Writing assertions
+
+You can add test specifications and assertions to your scripts using the [pm.test](#pmtest) and [pm.expect](#pmexpect) functions respectively.
+
+#### pm.test
+
+* Use the `pm.test` function to add test specifications to your **Pre-invoke** or **Response** script.
+
+  ><code>pm.test: (testName: <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#string_type' target='_blank'>string</a>, specFunction: <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions' target='_blank'>Function</a>) => <a href='#the-pm-object'>pm</a></code>
+
+  Use `testName` to help you identify the test in the **Test results** section and also communicate the test's purpose to the consumers of your collection.
+
+  `specFunction` is where you define the assertions on request and response data using the `pm.expect` function.
+
+  The `pm.test` method returns the `pm` object, making the call chainable.
+
+  Example test suite:
+
+  ```javascript
+  pm.test("response should have 'content-type' metadata", function () {
+    pm.response.to.have.metadata('content-type', 'application/grpc');
+  });
+  ```
+
+  An optional `done` callback can be passed to `pm.test`, to test asynchronous functions:
+
+  ```javascript
+  pm.test('async test', function (done) {
+    setTimeout(() => {
+      pm.expect(pm.response.statusCode).to.equal(0);
+      done();
+    }, 1500);
+  });
+  ```
+
+  You can also include multiple assertions to group the related ones in a single test.
+
+  ```javascript
+  pm.test("Should receive update events for both users", function () {
+    pm.response.messages.to.include({ action: 'update', userId: 'user1' });
+    pm.response.messages.to.include({ action: 'update', userId: 'user2' });
+  });
+  ```
+
+* Get the total number of tests executed from a specific location in code:
+
+  ><code>pm.test.index: () => <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#number_type' target='_blank'>number</a></code>
+
+* Skip a test using:
+
+  ><code>pm.test.skip: (testName: <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#string_type' target='_blank'>string</a>, specFunction: <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions' target='_blank'>Function</a>) => <a href='#the-pm-object'>pm</a></code>
+
+#### pm.expect
+
+The `pm.expect` method allows you to write assertions on your request and response data, using <a href='https://www.chaijs.com/api/bdd/' target='_blank'>ChaiJS expect BDD</a> syntax.
+
+><code>pm.expect: (assertOn: any) => Assertion </code>
+
+You can also use `pm.request.to.have.*`, `pm.response.to.have.*` and `pm.response.to.be.*` to build your assertions.
+
+```javascript
+pm.response.to.have.statusCode(0);
+pm.expect(pm.response.responseTime).to.be.below(200);
+```
+
+Check out the [examples](/postman-api-client/grpc-client/writing-scripts/test-examples) section for more assertions.
+
+### Using variables in scripts
+
+Head over to our comprehensive guide [here](https://learning.postman.com/docs/writing-scripts/script-references/postman-sandbox-api-reference/#using-variables-in-scripts) to learn about using variables in scripts.
+
+## Using external libraries
+
+To use a library, `require` the module by passing its name, and assign the returned exported module content to a variable.
+
+><code>require(moduleName: <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#string_type' target='_blank'>string</a>): any</code>
+
+The `require` method allows you to use the sandbox built-in library modules. The list of available libraries is listed below with links to the corresponding documentation.
+
+* [ajv](https://www.npmjs.com/package/ajv)
+* [atob](https://www.npmjs.com/package/atob)
+* [btoa](https://www.npmjs.com/package/btoa)
+* [chai](https://www.chaijs.com/)
+* [cheerio](https://cheerio.js.org/)
+* [crypto-js](https://www.npmjs.com/package/crypto-js)
+* [csv-parse/lib/sync](https://csv.js.org/parse/)
+* [lodash](https://lodash.com/)
+* [moment](https://momentjs.com/docs/)
+* [postman-collection](http://www.postmanlabs.com/postman-collection/)
+* [tv4](https://github.com/geraintluff/tv4)
+* [uuid](https://www.npmjs.com/package/uuid)
+* [xml2js](https://www.npmjs.com/package/xml2js)
+
+The following NodeJS modules are also available to use in the sandbox:
+
+* [path](https://nodejs.org/api/path.html)
+* [assert](https://nodejs.org/api/assert.html)
+* [buffer](https://nodejs.org/api/buffer.html)
+* [util](https://nodejs.org/api/util.html)
+* [url](https://nodejs.org/api/url.html)
+* [punycode](https://nodejs.org/api/punycode.html)
+* [querystring](https://nodejs.org/api/querystring.html)
+* [string-decoder](https://nodejs.org/api/string_decoder.html)
+* [stream](https://nodejs.org/api/stream.html)
+* [timers](https://nodejs.org/api/timers.html)
+* [events](https://nodejs.org/api/events.html)

--- a/src/pages/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request.md
+++ b/src/pages/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request.md
@@ -1,0 +1,23 @@
+---
+title: "Scripting in gRPC request"
+page_id: "scripting-in-grpc-request"
+warning: false
+updated: 2022-07-22
+contextual_links:
+  - type: section
+    name: "Prerequisites"
+  - type: link
+    name: "Using gRPC request"
+    url: "/postman-api-client/grpc-client/using-grpc-request/"
+---
+
+Postman contains a powerful scripting environment that allows you to add Javascript code (a.k.a scripts) in your gRPC requests. You can define scripts for two hooks available during the request execution lifecycle:
+
+1. Before invoking the method and establishing a connection with the server, under the **Pre-invoke** tab.
+2. After closing the connection with the server, under the **Response** tab.
+
+You can use scripts to write API tests, debug your requests (by logging to [Postman Console](https://learning.postman.com/docs/sending-requests/troubleshooting-api-requests/)), or even dynamically read/update the values of [variables]((https://learning.postman.com/docs/sending-requests/variables/)).
+
+&lt;Add GIF&gt;
+
+This is all powered by [Postman Sandbox](https://learning.postman.com/labs/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/), a JavaScript execution environment available to you while writing your Pre-invoke and Response scripts. Whatever code you write in these scripts is executed in the sandbox.

--- a/src/pages/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request.md
+++ b/src/pages/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request.md
@@ -1,0 +1,23 @@
+---
+title: "Scripting in gRPC request"
+page_id: "scripting-in-grpc-request"
+warning: false
+updated: 2022-07-22
+contextual_links:
+  - type: section
+    name: "Prerequisites"
+  - type: link
+    name: "Using gRPC request"
+    url: "/postman-api-client/grpc-client/using-grpc-request/"
+---
+
+Postman contains a powerful scripting environment that allows you to add Javascript code (a.k.a scripts) in your gRPC requests. You can define scripts for two hooks available during the request execution lifecycle:
+
+1. Before invoking the method and establishing a connection with the server, under the **Pre-invoke** tab.
+2. After closing the connection with the server, under the **Response** tab.
+
+You can use scripts to write API tests, debug your requests (by logging to [Postman Console](https://learning.postman.com/docs/sending-requests/troubleshooting-api-requests/)), or even dynamically read/update the values of [variables]((https://learning.postman.com/docs/sending-requests/variables/)).
+
+<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/writing-scripts/navigating-to-grpc-scripts.gif" alt="Navigating to scripts in gRPC request">
+
+This is all powered by [Postman Sandbox](https://learning.postman.com/labs/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/), a JavaScript execution environment available to you while writing your Pre-invoke and Response scripts. Whatever code you write in these scripts is executed in the sandbox.

--- a/src/pages/postman-api-client/grpc-client/writing-scripts/test-examples.md
+++ b/src/pages/postman-api-client/grpc-client/writing-scripts/test-examples.md
@@ -1,0 +1,228 @@
+---
+title: "Test examples"
+page_id: "test-examples"
+warning: false
+updated: 2022-07-22
+contextual_links:
+  - type: section
+    name: "Prerequisites"
+  - type: link
+    name: "Writing tests"
+    url: "/postman-api-client/grpc-client/writing-scripts/writing-tests/"
+---
+
+You can [write tests](/postman-api-client/grpc-client/writing-scripts/writing-tests/) for your gRPC request using [scripts](/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/). Depending on the logic and how you want to get the results, there are various ways in which the test assertions can be structured. This section will cover some of the most common ways to write assertions, along with an extensive list of examples explaining how to use [pm.* APIs](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/) to write tests.
+
+## Contents
+
+* [Testing status code](#testing-status-code)
+* [Testing response time](#testing-response-time)
+* [Testing metadata](#testing-metadata)
+* [Testing response trailers](#testing-response-trailers)
+* [Testing response](#testing-response)
+    * [Testing existence of a message](#testing-existence-of-a-message)
+    * [Testing for a message with specific property](#testing-for-a-message-with-specific-property)
+    * [Testing for a common property across all messages](#testing-for-a-common-property-across-all-messages)
+    * [Testing message(s) against a JSON schema](#testing-messages-against-a-json-schema)
+* [Working with a stream of messages](#working-with-a-stream-of-messages)
+
+## Testing status code
+
+ You can use the `statusCode` property available over [pm.response](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/#pmresponse) to test the status code of the response.
+
+```javascript
+pm.test('Status code is 0', () => {
+  pm.response.to.have.statusCode(0);
+});
+```
+
+You can also assert the same using the [pm.expect](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/#pmexpect) method
+
+```javascript
+pm.test('Status code is 0', () => {
+  pm.expect(pm.response.statusCode).to.equal(0);
+});
+```
+
+>Pro tip: You can use the `pm.response.to.be.ok` as a shorthand to test if the status code is 0.
+
+## Testing response time
+
+For a request with unary method, you can assert the response time as follows:
+
+```javascript
+pm.test('Response time is below 200ms', () => {
+  pm.response.to.have.responseTime.below(200);
+
+  // or
+  pm.response.to.have.responseTime.not.above(200);
+  
+  // Using pm.expect
+  pm.expect(pm.response.responseTime).to.be.below(300);
+});
+```
+
+For requests with streaming methods, `pm.response.responseTime` denotes the total duration for that request execution.
+
+## Testing metadata
+
+To check if a response metadata is present:
+
+```javascript
+pm.test('"content-type" is present in response metadata', () => {
+  pm.response.to.have.metadata('content-type');
+
+  // Using pm.expect
+  pm.expect(pm.response.metadata.has('content-type')).to.be.true;
+});
+```
+
+You can also assert the value of the metadata:
+
+```javascript
+pm.test('"content-type" response metadata is "application/grpc"', () => {
+  pm.response.to.have.metadata('content-type', 'application/grpc');
+
+  // Using pm.expect
+  pm.expect(pm.response.metadata.get('content-type')).to.equal('application/grpc');
+});
+```
+
+Similar assertions can be written for request metadata using the [pm.request](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/#pmrequest) object.
+
+## Testing response trailers
+
+To check if a response trailer is present:
+
+```javascript
+pm.test('"grpc-status-details-bin" is present in response trailers', () => {
+  pm.response.to.have.trailer('grpc-status-details-bin');
+
+  // Using pm.expect
+  pm.expect(pm.response.trailers.has('grpc-status-details-bin')).to.be.true;
+});
+```
+
+You can also assert the value of the trailer:
+
+```javascript
+pm.test('"grpc-status-details-bin" response trailer is "dummy-value"', () => {
+  pm.response.to.have.trailer('grpc-status-details-bin', 'dummy-value');
+
+  // Using pm.expect
+  pm.expect(pm.response.trailers.get('grpc-status-details-bin')).to.equal('dummy-value');
+});
+```
+
+## Testing response
+
+In case of multiple response messages (request with the server or bidirectional streaming method), the below tests will check all the messages for the given assertion. While, for a request with unary or client streaming method, where there is only one response message, the assertion will be done on that single message only.
+
+Also, when writing assertions using `pm.response.messages.to.*` , you will be asserting on an array of message content and not the complete message object mentioned [here](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/#pmresponse).
+
+All the below shown assertions can done on request message(s) as well using  `pm.request` object.
+
+### Testing existence of a message
+
+To test the existence of a response message (strictly)
+
+```javascript
+pm.test('"Correct user details are received"', () => {
+  pm.response.to.have.message({
+    userId: '123'
+    name: 'John Doe',
+    email: 'john@example.com',
+    phone: '+1-555-555-5555'
+    age: 30,
+    company: 'XYZ'
+  });
+});
+```
+
+### Testing for a message with specific property
+
+You can assert that the given object's properties are a subset of any messages received as a response.
+
+```javascript
+pm.test('"User details are updated successfully"', () => {
+  pm.response.messages.to.include({
+    action: 'update-user-details',
+    status: 'success'
+  });
+});
+```
+
+> By default, pm.response.messages.to.include() has `.deep` applied on it
+
+### Testing for a common property across all messages
+
+To check if a common property exists in all the received messages:
+
+```javascript
+pm.test('All users have "company" in their profile', () => {
+  pm.response.messages.to.have.property('isActive');
+});
+```
+
+You can assert the value as well of the common property:
+
+```javascript
+pm.test('All users are in same company', () => {
+  pm.response.messages.to.have.property('company', 'XYZ');
+});
+```
+
+>By default, `pm.response.messages.to.have.property()` has `.deep` and `.nested` applied on it
+
+### Testing message(s) against a JSON schema
+
+You can assert that the received messages match the given JSON schema:
+
+```javascript
+const schema = {
+  type: "object",
+  properties: {
+    username: {
+      type: "string",
+      pattern: "^[a-z0-9_-]{3,16}$"
+    }
+  }
+};
+  
+pm.test('All response messages have correct username', () => {
+  pm.response.messages.to.have.jsonSchema(schema);
+});
+
+pm.test('Assert on a specific message', () => {
+  pm.expect(pm.response.messages.idx(10).data).to.have.jsonSchema(schema);
+});
+```
+
+## Working with a stream of messages
+
+Check out the below examples to understand how to work with a stream of messages and write assertions on them.
+
+```javascript
+pm.test('Should receive keep-alive message roughly every 5 seconds', () => {
+  const keepAliveMessage = pm.response.messages.filter({
+    data: {
+      type: 'keep-alive'
+    }
+  });
+
+  for (let i = 1; i < keepAliveMessage.length; i++) {
+    const time1 = keepAliveMessage[i-1].timestamp;
+    const time2 = keepAliveMessage[i].timestamp;
+
+    pm.expect(time2-time1).to.be.within(4800, 5200);
+  }
+});
+```
+
+```javascript
+pm.test('Every request message should have a corresponding response message', () => {
+  pm.request.messages.each((reqMsg) => {
+    pm.response.messages.to.include({ id: reqMsg.data.id });
+  });
+});
+```

--- a/src/pages/postman-api-client/grpc-client/writing-scripts/test-examples.md
+++ b/src/pages/postman-api-client/grpc-client/writing-scripts/test-examples.md
@@ -1,0 +1,228 @@
+---
+title: "Test examples"
+page_id: "test-examples"
+warning: false
+updated: 2022-07-22
+contextual_links:
+  - type: section
+    name: "Prerequisites"
+  - type: link
+    name: "Writing tests"
+    url: "/postman-api-client/grpc-client/writing-scripts/writing-tests/"
+---
+
+You can [write tests](/postman-api-client/grpc-client/writing-scripts/writing-tests/) for your gRPC request using [scripts](/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/). Depending on the logic and how you want to get the results, there are various ways in which the test assertions can be structured. This section will cover some of the most common ways to write assertions, along with an extensive list of examples explaining how to use [pm.* APIs](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/) to write tests.
+
+## Contents
+
+* [Testing status code](#testing-status-code)
+* [Testing response time](#testing-response-time)
+* [Testing metadata](#testing-metadata)
+* [Testing response trailers](#testing-response-trailers)
+* [Testing response](#testing-response)
+    * [Testing existence of a message](#testing-existence-of-a-message)
+    * [Testing for a message with specific property](#testing-for-a-message-with-specific-property)
+    * [Testing for a common property across all messages](#testing-for-a-common-property-across-all-messages)
+    * [Testing message(s) against a JSON schema](#testing-messages-against-a-json-schema)
+* [Working with a stream of messages](#working-with-a-stream-of-messages)
+
+## Testing status code
+
+ You can use the `statusCode` property available over [pm.response](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/#pmresponse) to test the status code of the response.
+
+```javascript
+pm.test('Status code is 0', () => {
+  pm.response.to.have.statusCode(0);
+});
+```
+
+You can also assert the same using the [pm.expect](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/#pmexpect) method
+
+```javascript
+pm.test('Status code is 0', () => {
+  pm.expect(pm.response.statusCode).to.equal(0);
+});
+```
+
+>Pro tip: You can use the `pm.response.to.be.ok` as a shorthand to test if the status code is 0.
+
+## Testing response time
+
+For a request with unary method, you can assert the response time as follows:
+
+```javascript
+pm.test('Response time is below 200ms', () => {
+  pm.response.to.have.responseTime.below(200);
+
+  // or
+  pm.response.to.have.responseTime.not.above(200);
+  
+  // Using pm.expect
+  pm.expect(pm.response.responseTime).to.be.below(300);
+});
+```
+
+For requests with streaming methods, `pm.response.responseTime` denotes the total duration for that request execution.
+
+## Testing metadata
+
+To check if a response metadata is present:
+
+```javascript
+pm.test('"content-type" is present in response metadata', () => {
+  pm.response.to.have.metadata('content-type');
+
+  // Using pm.expect
+  pm.expect(pm.response.metadata.has('content-type')).to.be.true;
+});
+```
+
+You can also assert the value of the metadata:
+
+```javascript
+pm.test('"content-type" response metadata is "application/grpc"', () => {
+  pm.response.to.have.metadata('content-type', 'application/grpc');
+
+  // Using pm.expect
+  pm.expect(pm.response.metadata.get('content-type')).to.equal('application/grpc');
+});
+```
+
+Similar assertions can be written for request metadata using the [pm.request](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/#pmrequest) object.
+
+## Testing response trailers
+
+To check if a response trailer is present:
+
+```javascript
+pm.test('"grpc-status-details-bin" is present in response trailers', () => {
+  pm.response.to.have.trailer('grpc-status-details-bin');
+
+  // Using pm.expect
+  pm.expect(pm.response.trailers.has('grpc-status-details-bin')).to.be.true;
+});
+```
+
+You can also assert the value of the trailer:
+
+```javascript
+pm.test('"grpc-status-details-bin" response trailer is "dummy-value"', () => {
+  pm.response.to.have.trailer('grpc-status-details-bin', 'dummy-value');
+
+  // Using pm.expect
+  pm.expect(pm.response.trailers.get('grpc-status-details-bin')).to.equal('dummy-value');
+});
+```
+
+## Testing response
+
+In case of multiple response messages (request with the server or bidirectional streaming method), the below tests will check all the messages for the given assertion. While, for a request with unary or client streaming method, where there is only one response message, the assertion will be done on that single message only.
+
+Also, when writing assertions using `pm.response.messages.to.*` , you will be asserting on an array of message content and not the complete message object mentioned [here](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api/#pmresponse).
+
+All the below assertions can done on request message(s) as well using `pm.request` object.
+
+### Testing existence of a message
+
+To test the existence of a response message (strictly)
+
+```javascript
+pm.test('Correct user details are received', () => {
+  pm.response.to.have.message({
+    userId: '123',
+    name: 'John Doe',
+    email: 'john@example.com',
+    phone: '+1-555-555-5555',
+    age: 30,
+    company: 'XYZ'
+  });
+});
+```
+
+### Testing for a message with specific property
+
+You can assert that the given object's properties are a subset of any messages received as a response.
+
+```javascript
+pm.test('User details are updated successfully', () => {
+  pm.response.messages.to.include({
+    action: 'update-user-details',
+    status: 'success'
+  });
+});
+```
+
+> By default, pm.response.messages.to.include() has `.deep` applied on it
+
+### Testing for a common property across all messages
+
+To check if a common property exists in all the received messages:
+
+```javascript
+pm.test('All users have "company" in their profile', () => {
+  pm.response.messages.to.have.property('isActive');
+});
+```
+
+You can assert the value as well of the common property:
+
+```javascript
+pm.test('All users are in same company', () => {
+  pm.response.messages.to.have.property('company', 'XYZ');
+});
+```
+
+>By default, `pm.response.messages.to.have.property()` has `.deep` and `.nested` applied on it
+
+### Testing message(s) against a JSON schema
+
+You can assert that the received messages match the given JSON schema:
+
+```javascript
+const schema = {
+  type: "object",
+  properties: {
+    username: {
+      type: "string",
+      pattern: "^[a-z0-9_-]{3,16}$"
+    }
+  }
+};
+  
+pm.test('All response messages have correct username', () => {
+  pm.response.messages.to.have.jsonSchema(schema);
+});
+
+pm.test('Assert on a specific message', () => {
+  pm.expect(pm.response.messages.idx(10).data).to.have.jsonSchema(schema);
+});
+```
+
+## Working with a stream of messages
+
+Check out the below examples to understand how to work with a stream of messages and write assertions on them.
+
+```javascript
+pm.test('Should receive keep-alive message roughly every 5 seconds', () => {
+  const keepAliveMessage = pm.response.messages.filter({
+    data: {
+      type: 'keep-alive'
+    }
+  });
+
+  for (let i = 1; i < keepAliveMessage.length; i++) {
+    const time1 = keepAliveMessage[i-1].timestamp;
+    const time2 = keepAliveMessage[i].timestamp;
+
+    pm.expect(time2-time1).to.be.within(4800, 5200);
+  }
+});
+```
+
+```javascript
+pm.test('Every request message should have a corresponding response message', () => {
+  pm.request.messages.each((reqMsg) => {
+    pm.response.messages.to.include({ id: reqMsg.data.id });
+  });
+});
+```

--- a/src/pages/postman-api-client/grpc-client/writing-scripts/writing-tests.md
+++ b/src/pages/postman-api-client/grpc-client/writing-scripts/writing-tests.md
@@ -1,0 +1,106 @@
+---
+title: "Writing tests"
+page_id: "writing-tests"
+warning: false
+updated: 2022-07-22
+contextual_links:
+  - type: section
+    name: "Prerequisites"
+  - type: link
+    name: "Scripting in gRPC request"
+    url: "/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/"
+  - type: section
+    name: "Blog Posts"
+  - type: link
+    name: "Testing gRPC APIs with Postman"
+    url: "https://blog.postman.com/"
+---
+
+Tests ensure that your APIs are working as expected and consistently delivering the necessary functionality, performance, reliability, and security. You can write test suites for your gRPC requests using Postman's powerful Javascript-based scripting environment. Tests get executed along with the request and provide you with the results summary at the end.
+
+## Contents
+
+* [Adding tests](#adding-tests)
+    * [Using snippets](#using-snippets)
+    * [Writing your assertions](#writing-your-assertions)
+* [Running your tests](#running-your-tests)
+* [Checking test results](#checking-test-results)
+* [Debugging your tests](#debugging-your-tests)
+* [Next step](#next-up)
+
+## Adding tests
+
+You can leverage [scripts](/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/) to write tests for your gRPC requests. To do so:
+
+1. Go to the **Scripts** tab in your gRPC request.
+2. Select the execution hook (**Pre-invoke** or **Response**) to which you want to add a test.
+3. Use [snippets](#using-snippets) from the right panel to add a test or [write customized assertions](#writing-your-assertions).
+
+Both the execution hooks are available for all gRPC requests irrespective of the method type being unary, client streaming, server streaming, or bidirectional streaming. Your scripts can include however many tests you need and will save along with the rest of your request when you click **Save**.
+
+### Using snippets
+
+You can use the pre-curated list of commonly used test code snippets to write your tests. **Snippets** are available in the right panel of the script editor. Selecting a snippet adds the required code automatically to your script, helping you get started quickly with your testing. Once added to your script, you can edit the snippets (if needed) to meet your specific testing requirements.
+
+&lt;Add GIF&gt;
+
+### Writing your assertions
+
+You can add test specifications from scratch using the `pm.test` function. It takes two arguments:
+
+* `testName` string to identify and communicate the purpose of your test. The name will appear in your test result output.
+* `specFunction` where the assertions are defined.
+
+The `pm.expect` method allows you to write assertions on your request/response data, using <a href='https://www.chaijs.com/api/bdd/' target='_blank'>ChaiJS expect BDD</a> syntax. For example, a test to assert the response status code will look something like this:
+
+```javascript
+pm.test("Status code is 0 OK", function () {
+  pm.expect(response.statusCode).to.equal(0);
+});
+```
+
+The `pm.request` and `pm.response` object is available in scripts that contains all the necessary information about the current request and response, respectively, for you to write the assertions as per your need. To explore the full range of things you can do with the `pm` object, check out the [Postman Sandbox API reference](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api).
+
+You can also add tests on the environment variables using the `pm.environment` method. For example, a test to assert the type of environment will look something like this:
+
+```javascript
+pm.test("Environment to be production", function () {
+    pm.expect(pm.environment.get("env")).to.equal("production");
+});
+```
+
+The script editor also has a built-in auto-complete feature for Javascript and pm.* APIs that helps you write your assertions faster and accurately.
+
+&lt;Add GIF&gt;
+
+Check out the comprehensive list of [example tests](/postman-api-client/grpc-client/writing-scripts/examples) to even better understand how to write your own tests for some common scenarios.
+
+## Running your tests
+
+To run your tests, click **Invoke**. Test suites present in the Pre-invoke script will be executed first, followed by the ones in Response script. If you wish to stop the request execution at any point, you can manually click **Cancel**. Doing so will also abort the execution of any scripts further.
+
+> If there are any errors in your Pre-invoke script, it will abort the request execution.
+
+To learn more about how to debug your tests, head over to [debugging your tests](#debugging-your-tests).
+
+> If you are using Postman for Web, you must use the Postman Desktop Agent. See [Using Postman on the web](https://learning.postman.com/docs/getting-started/installation-and-updates/#using-postman-on-the-web) for more information.
+
+## Checking test results
+
+To check the results of your tests, go to the **Test results** tab in the response section. The tab header shows the passed and total executed tests count. You can also filter the result based on the test status (**Passed**, **Skipped**, and **Failed**).
+
+&lt;Add GIF&gt;
+
+## Debugging your tests
+
+If you are having trouble with your tests,
+
+* Check if there are any errors in your scripts. A red badge will highlight scripts with errors. You can also check the response section for specific errors.
+* Debug your tests using the [log statements](https://learning.postman.com/docs/sending-requests/troubleshooting-api-requests/#using-log-statements) to ensure that you are asserting on correct data.
+* Still facing issues? Do not worry, submit a [bug report/feedback](http://localhost:8000/postman-api-client/grpc-client/troubleshooting/#submit-a-bug-reportfeedback) and we will try our best to help you.
+
+&lt;Add GIF&gt;
+
+## Next steps
+
+Now that you know how to write tests for your gRPC requests, you can check out some of the standard [test script examples](/postman-api-client/grpc-client/writing-scripts/test-examples) you can use to write your own tests. Also, refer to the [Postman Sandbox API](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api) to dive deeper into the available features and information in your scripts.

--- a/src/pages/postman-api-client/grpc-client/writing-scripts/writing-tests.md
+++ b/src/pages/postman-api-client/grpc-client/writing-scripts/writing-tests.md
@@ -1,0 +1,100 @@
+---
+title: "Writing tests"
+page_id: "writing-tests"
+warning: false
+updated: 2022-07-22
+contextual_links:
+  - type: section
+    name: "Prerequisites"
+  - type: link
+    name: "Scripting in gRPC request"
+    url: "/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/"
+---
+
+Tests ensure that your APIs are working as expected and consistently delivering the necessary functionality, performance, reliability, and security. You can write test suites for your gRPC requests using Postman's powerful Javascript-based scripting environment. Tests get executed along with the request and provide you with the results summary at the end.
+
+## Contents
+
+* [Adding tests](#adding-tests)
+    * [Using snippets](#using-snippets)
+    * [Writing your assertions](#writing-your-assertions)
+* [Running your tests](#running-your-tests)
+* [Checking test results](#checking-test-results)
+* [Debugging your tests](#debugging-your-tests)
+* [Next step](#next-up)
+
+## Adding tests
+
+You can leverage [scripts](/postman-api-client/grpc-client/writing-scripts/scripting-in-grpc-request/) to write tests for your gRPC requests. To do so:
+
+1. Go to the **Scripts** tab in your gRPC request.
+2. Select the execution hook (**Pre-invoke** or **Response**) to which you want to add a test.
+3. Use [snippets](#using-snippets) from the right panel to add a test or [write customized assertions](#writing-your-assertions).
+
+Both the execution hooks are available for all gRPC requests irrespective of the method type being unary, client streaming, server streaming, or bidirectional streaming. Your scripts can include however many tests you need and will save along with the rest of your request when you click **Save**.
+
+### Using snippets
+
+You can use the pre-curated list of commonly used test code snippets to write your tests. **Snippets** are available in the right panel of the script editor. Selecting a snippet adds the required code automatically to your script, helping you get started quickly with your testing. Once added to your script, you can edit the snippets (if needed) to meet your specific testing requirements.
+
+<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/writing-scripts/using-snippets-in-grpc-scripts.gif" alt="Using snippets">
+
+### Writing your assertions
+
+You can add test specifications from scratch using the `pm.test` function. It takes two arguments:
+
+* `testName` string to identify and communicate the purpose of your test. The name will appear in your test result output.
+* `specFunction` where the assertions are defined.
+
+The `pm.expect` method allows you to write assertions on your request/response data, using <a href='https://www.chaijs.com/api/bdd/' target='_blank'>ChaiJS expect BDD</a> syntax. For example, a test to assert the response status code will look something like this:
+
+```javascript
+pm.test("Status code is 0 OK", function () {
+  pm.expect(response.statusCode).to.equal(0);
+});
+```
+
+The `pm.request` and `pm.response` object is available in scripts that contains all the necessary information about the current request and response, respectively, for you to write the assertions as per your need. To explore the full range of things you can do with the `pm` object, check out the [Postman Sandbox API reference](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api).
+
+You can also add tests on the environment variables using the `pm.environment` method. For example, a test to assert the type of environment will look something like this:
+
+```javascript
+pm.test("Environment to be production", function () {
+    pm.expect(pm.environment.get("env")).to.equal("production");
+});
+```
+
+The script editor also has a built-in auto-complete feature for Javascript and pm.* APIs that helps you write your assertions faster and accurately.
+
+<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/writing-scripts/grpc-scripts-autocompletion.gif" alt="Autocompletion in scripts">
+
+Check out the comprehensive list of [example tests](/postman-api-client/grpc-client/writing-scripts/examples) to even better understand how to write your own tests for some common scenarios.
+
+## Running your tests
+
+To run your tests, click **Invoke**. Test suites present in the Pre-invoke script will be executed first, followed by the ones in Response script. If you wish to stop the request execution at any point, you can manually click **Cancel**. Doing so will also abort the execution of any scripts further.
+
+> If there are any errors in your Pre-invoke script, it will abort the request execution.
+
+To learn more about how to debug your tests, head over to [debugging your tests](#debugging-your-tests).
+
+> If you are using Postman for Web, you must use the Postman Desktop Agent. See [Using Postman on the web](https://learning.postman.com/docs/getting-started/installation-and-updates/#using-postman-on-the-web) for more information.
+
+## Checking test results
+
+To check the results of your tests, go to the **Test results** tab in the response section. The tab header shows the passed and total executed tests count. You can also filter the result based on the test status (**Passed**, **Skipped**, and **Failed**).
+
+<img src="https://assets.postman.com/postman-labs-docs/grpc-docs/writing-scripts/invoke-grpc-request-with-tests.gif" alt="Checking test results">
+
+## Debugging your tests
+
+If you are having trouble with your tests,
+
+* Check if there are any errors in your scripts. A red badge will highlight scripts with errors. You can also check the response section for specific errors.
+  <img src="https://assets.postman.com/postman-labs-docs/grpc-docs/writing-scripts/debugging-error-in-grpc-scripts.gif" alt="Debugging error in scripts">
+* Debug your tests using the [log statements](https://learning.postman.com/docs/sending-requests/troubleshooting-api-requests/#using-log-statements) to ensure that you are asserting on correct data.
+* Still facing issues? Do not worry, submit a [bug report/feedback](http://localhost:8000/postman-api-client/grpc-client/troubleshooting/#submit-a-bug-reportfeedback) and we will try our best to help you.
+
+## Next steps
+
+Now that you know how to write tests for your gRPC requests, you can check out some of the standard [test script examples](/postman-api-client/grpc-client/writing-scripts/test-examples) you can use to write your own tests. Also, refer to the [Postman Sandbox API](/postman-api-client/grpc-client/writing-scripts/postman-sandbox-api) to dive deeper into the available features and information in your scripts.


### PR DESCRIPTION
- Added the "Writing scripts" section in the left navigation bar.
- Added the following pages under the "Writing scripts" section
  - "Scripting in gRPC request"
  - "Writing tests"
  - "Test examples" and
  -  "Postman Sandbox API" 
pages under the "Test scripts" section.

To Do:
- Add GIFs

<img width="1629" alt="image" src="https://user-images.githubusercontent.com/24985700/181489219-0c790fd1-0b27-41d2-af3f-dc3ba344f829.png">
<img width="1317" alt="image" src="https://user-images.githubusercontent.com/24985700/181489254-0cce8136-6933-43df-b944-836a78059469.png">
<img width="1328" alt="image" src="https://user-images.githubusercontent.com/24985700/181489323-95cdc00f-5d53-4131-9dd7-d5c77015154d.png">
<img width="1298" alt="image" src="https://user-images.githubusercontent.com/24985700/181489350-541ce010-aedb-439b-b245-f80c31bc2099.png">

