### PR TITLE
Change issue assignee to Sterling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Report typos, broken links, or other documentation errors
 title: ''
 labels: bug
-assignees: jkonrath-postman
+assignees: SterlingChin
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -3,7 +3,7 @@ name: Documentation request
 about: Suggest ideas for new documentation
 title: ''
 labels: enhancement
-assignees: jkonrath-postman
+assignees: SterlingChin
 
 ---
 


### PR DESCRIPTION
I think because this repo was a copy of the LC one, it's auto-assigning new GitHub issues to me. Let's dump them on Sterling instead. :)