### PR TITLE
[MARKENG-2419][c] Update LC:labs-docs to use G-CX7P9K6W67

### DIFF
--- a/bff.js
+++ b/bff.js
@@ -114,8 +114,7 @@ setTimeout(function(){
           function gtag(){dataLayer.push(arguments);}
           window.gtag = gtag;
           gtag('js', new Date());
-          gtag('config', 'UA-43979731-4');
-          window.pmt('log', ['gtag: UA-43979731-4']);
+          gtag('config', '${UACode}');
           window.pmt('ga', ['${UACode}', sitename]);
           window.pmt('log', ['initialized GA: ' + sitename + ' (' + '${UACode}' + ')']);
           window._iaq = window._iaq || {};


### PR DESCRIPTION
### What are the changes? 
_Branched from `main`_, this updates the web app to us G-CX7P9K6W67 for GA

### Why make these changes?  
So that metrics are accurately collected in GA

*no-visuals