### PR TITLE
fix: remove use of `polyfill.io`

### DIFF
--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -101,13 +101,6 @@
        <script type="text/javascript" src="https://cdn.cookielaw.org/consent/1cef3369-6d07-4928-b977-2d877eb670c4/OtAutoBlock.js" />
        <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" type="text/javascript" charset="UTF-8" data-domain-script="1cef3369-6d07-4928-b977-2d877eb670c4" />
        <link rel="canonical" href={`https://learning.postman.com${site.siteMetadata.pathPrefix}${slug}`} />
-       {/* Algolia Instantsearch IE11 support v3 */}
-       {/* <script src="https:/cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=default,Array.prototype.find,Array.prototype.includes" /> */}
-       {/*  */}
-       {/* Algolia Instantsearch IE11 support v4 */}
-       <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com" />
-       <link crossOrigin rel="preconnect" href="https://cdnjs.cloudflare.com" />
-       <script async src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries"></script>
      </Helmet>
    );
  }

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -102,12 +102,12 @@
        <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" type="text/javascript" charset="UTF-8" data-domain-script="1cef3369-6d07-4928-b977-2d877eb670c4" />
        <link rel="canonical" href={`https://learning.postman.com${site.siteMetadata.pathPrefix}${slug}`} />
        {/* Algolia Instantsearch IE11 support v3 */}
-       {/* <script src="https://polyfill.io/v3/polyfill.min.js?features=default,Array.prototype.find,Array.prototype.includes" /> */}
+       {/* <script src="https:/cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=default,Array.prototype.find,Array.prototype.includes" /> */}
        {/*  */}
        {/* Algolia Instantsearch IE11 support v4 */}
-       <link rel="dns-prefetch" href="https://polyfill.io" />
-       <link crossOrigin rel="preconnect" href="https://polyfill.io" />
-       <script async src="https://polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries"></script>
+       <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com" />
+       <link crossOrigin rel="preconnect" href="https://cdnjs.cloudflare.com" />
+       <script async src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries"></script>
      </Helmet>
    );
  }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -41,7 +41,7 @@ class IndexPage extends React.Component {
       polyfill.id = id
       polyfill.language = "JavaScript1.1"
       polyfill.src =
-        "//polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries"
+        "//cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries"
       polyfill.async = true
       document.body.appendChild(polyfill)
     }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -34,17 +34,6 @@ class IndexPage extends React.Component {
       "//pixel.mathtag.com/event/js?mt_id=1538259&mt_adid=244742&mt_exem=&mt_excl=&v1=&v2=&v3=&s1=&s2=&s3="
     pix.async = true
     document.body.appendChild(pix)
-
-    const id = "Polyfill"
-    if (!document.getElementById(id)) {
-      const polyfill = document.createElement("script")
-      polyfill.id = id
-      polyfill.language = "JavaScript1.1"
-      polyfill.src =
-        "//cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries"
-      polyfill.async = true
-      document.body.appendChild(polyfill)
-    }
   }
 
   render() {


### PR DESCRIPTION
This PR addresses the recent security concerns regarding polyfill.io, as detailed in the [Cloudflare blog](https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet) and [the hacker news](https://thehackernews.com/2024/06/over-110000-websites-affected-by.html). The domain polyfill.io was sold to a new owner, Funnull, and has been used to inject malicious JavaScript code. To mitigate this risk, I have replaced all instances of polyfill.io in [`labs-docs`](https://learning.postman.com/labs/) repo  to Cloudflare's secure mirror.

From polyfill.io original creator: https://twitter.com/triblondon/status/1761852117579427975

Issue on their repo: https://github.com/polyfillpolyfill/polyfill-service/issues/2892